### PR TITLE
switch to phusion baseimage, and other cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-FROM ubuntu:14.04.2
+FROM phusion/baseimage:latest
 MAINTAINER James Humphrey <leafknode@gmail.com>
 
-RUN apt-get -y update
-RUN apt-get -y install software-properties-common python-software-properties
-RUN add-apt-repository -y ppa:webupd8team/java
-RUN apt-get -y update
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-RUN apt-get -y install oracle-java8-installer
+ENV DEBIAN_FRONTEND noninteractive
+ENV JAVA_VERSION 1.8.0
 
-# install useful utils
-RUN apt-get -y install wget
-RUN apt-get -y install tar
-RUN apt-get -y install curl
+# accept license
+RUN echo /usr/bin/debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 
-# Clean up APT when done.
+# config apt java repo
+RUN apt-get update
+RUN apt-get install -y python-software-properties
+RUN add-apt-repository ppa:webupd8team/java
+RUN apt-get remove -y python-software-properties
+RUN apt-get autoremove -y
+
+# install java
+RUN apt-get update
+RUN apt-get install -y wget oracle-java8-installer oracle-java8-set-default
+RUN apt-get autoremove -y
+RUN update-alternatives --display java
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
- switching to phusion baseimage underneath
- baseimage includes curl, wget, tar and more, so removed
